### PR TITLE
Updating hook used to enqueue front end scripts

### DIFF
--- a/wp-photo-sphere.php
+++ b/wp-photo-sphere.php
@@ -104,7 +104,7 @@ function wpps_register_scripts() {
 	wp_register_script('wpps-psv', plugin_dir_url(__FILE__) . 'lib/photo-sphere-viewer.min.js', array('wpps-three'), '2.9', true);
 	wp_register_script('wp-photo-sphere', plugin_dir_url(__FILE__) . 'wp-photo-sphere.js', array('jquery', 'wpps-psv'), '3.8', true);
 }
-add_action('plugins_loaded', 'wpps_register_scripts');
+add_action('wp_enqueue_scripts', 'wpps_register_scripts');
 
 function wpps_enqueue_admin_scripts() {
 	if (floatval(get_bloginfo('version')) >= 3.5)


### PR DESCRIPTION
Enqueuing scripts before the wp_enqueue_scripts, admin_enqueue_scripts, or login_enqueue_scripts hooks results in the following notice being printed by WordPress:

```
PHP Notice:  wp_register_script was called <strong>incorrectly</strong>. Scripts and styles should not be registered or enqueued until the <code>wp_enqueue_scripts</code>, <code>admin_enqueue_scripts</code>, or <code>login_enqueue_scripts</code> hooks. Please see <a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 3.3.0.)
```